### PR TITLE
Refactor parameter-related methods

### DIFF
--- a/osu.Framework.Live2D.Tests/Visual/TestSceneMotionQueue.cs
+++ b/osu.Framework.Live2D.Tests/Visual/TestSceneMotionQueue.cs
@@ -38,10 +38,7 @@ namespace osu.Framework.Live2D.Tests.Visual
             AddStep("stop motion", () => Sprite.StopMotion());
             AddAssert("check if stopped", () => !Sprite.IsMoving);
 
-            var parameters = typeof(CubismDefaultParameterId)
-                .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
-                .Select(f => f.GetValue(null) as string).ToArray();
-            Add(new ParameterMonitor(Sprite, parameters));
+            Add(new ParameterMonitor(Sprite, Parameters));
         }
     }
 }

--- a/osu.Framework.Live2D.Tests/Visual/TestSceneParameterModifiers.cs
+++ b/osu.Framework.Live2D.Tests/Visual/TestSceneParameterModifiers.cs
@@ -1,0 +1,14 @@
+using System.Linq;
+
+namespace osu.Framework.Live2D.Tests.Visual
+{
+    [System.ComponentModel.Description("Modify a model's parameters")]
+    public class TestSceneParameterModifiers : TestSceneBase
+    {
+        protected override void LoadComplete()
+        {
+            foreach (var param in Parameters.Where(p => Sprite.HasParameter(p)))
+                AddSliderStep<float>(param, 0, 1, 0, (newValue) => Sprite.SetParameterValue(param, newValue));
+        }
+    }
+}


### PR DESCRIPTION
Adds new methods for `CubismSprite`:
* `HasParameter(string)` safely checks whether if the model has that parameter.
* `GetParameterValue(string)` returns the parameter's value in percentage. Throws an error if that parameter doesn't exist.
* `SetParameterValue(string, double)` sets the parameter's value. The value must be in percent.
* `AddParameterValue(string, double)` is a shorthand for `GetParameter + SetParameter`.
* `SubtractParameterValue(string, double)` is a shorthand for `GetParameter - SetParameter`.
* `ResetParameters()` resets all parameters to its defaults.
* `ResetParameters(IEnumerable<string>)` resets all parameters in the list it was provided with.

`TestCaseParameterModifiers` is added as a sandbox for trying out and modifying specific model parameters.