### PR TITLE
Expose loader method

### DIFF
--- a/osu.Framework.Live2D/Graphics/Cubism/CubismAssetStore.cs
+++ b/osu.Framework.Live2D/Graphics/Cubism/CubismAssetStore.cs
@@ -25,20 +25,16 @@ namespace osu.Framework.Graphics.Cubism
         {
             if (string.IsNullOrEmpty(name)) return null;
 
-            CubismAsset asset;
-    
             try
             {
                 var baseDir = name.Split('.', 2)[0];
                 var mdlPath = name.Substring(baseDir.Length + 1, (name.Length - baseDir.Length) - 1);
-                asset = new CubismAsset($"{baseDir}/{mdlPath}", Retrieve);
+                return new CubismAsset($"{baseDir}/{mdlPath}", Retrieve);
             }
             catch (Exception e)
             {
                 throw e;
             }
-
-            return asset;
         }
 
         /// <summary>

--- a/osu.Framework.Live2D/Graphics/Cubism/CubismAssetStore.cs
+++ b/osu.Framework.Live2D/Graphics/Cubism/CubismAssetStore.cs
@@ -31,24 +31,7 @@ namespace osu.Framework.Graphics.Cubism
             {
                 var baseDir = name.Split('.', 2)[0];
                 var mdlPath = name.Substring(baseDir.Length + 1, (name.Length - baseDir.Length) - 1);
-                asset = new CubismAsset($"{baseDir}/{mdlPath}", (string path) =>
-                {
-                    // CubismFileLoader internally uses System.IO.Path
-                    path = path.Replace(Path.DirectorySeparatorChar, '.');
-                    path = path.Replace(Path.AltDirectorySeparatorChar, '.');
-
-                    // osu!framework prepends an underscore to numbers as file names
-                    var matches = new Regex(@"\.(\d+)").Matches(path);
-                    foreach (Match match in matches)
-                    {
-                        GroupCollection groups = match.Groups;
-                        var start = groups[1].Index;
-                        var end = start + groups[1].Length;
-                        path = path.Substring(0, start) + $"_{groups[1].Value}" + path.Substring(end, path.Length - end);
-                    }
-
-                    return GetStream(path);
-                });
+                asset = new CubismAsset($"{baseDir}/{mdlPath}", Retrieve);
             }
             catch (Exception e)
             {
@@ -56,6 +39,29 @@ namespace osu.Framework.Graphics.Cubism
             }
 
             return asset;
+        }
+
+        /// <summary>
+        /// The loader method for <see cref="CubismAsset"/>.
+        /// </summary>
+        /// <param name="path">The path to the file to load.</param>
+        protected virtual Stream Retrieve(string path)
+        {
+            // CubismFileLoader internally uses System.IO.Path
+            path = path.Replace(Path.DirectorySeparatorChar, '.');
+            path = path.Replace(Path.AltDirectorySeparatorChar, '.');
+
+            // osu!framework prepends an underscore to numbers as file names
+            var matches = new Regex(@"\.(\d+)").Matches(path);
+            foreach (Match match in matches)
+            {
+                GroupCollection groups = match.Groups;
+                var start = groups[1].Index;
+                var end = start + groups[1].Length;
+                path = path.Substring(0, start) + $"_{groups[1].Value}" + path.Substring(end, path.Length - end);
+            }
+
+            return GetStream(path);
         }
     }
 }


### PR DESCRIPTION
Prerequisite for vignette-project/vignette#10. Allows derived `CubismAssetStore` instances to have their own loader methods.